### PR TITLE
Fit sudoku grid to screen

### DIFF
--- a/css/sudoku.css
+++ b/css/sudoku.css
@@ -6,9 +6,12 @@
 td {
   border: 2px solid #222222;
   text-align: center;
-  font-size: 250%;
   color: #000000;
   font-family: irohamaru-mikami-Regular;
+  line-height: calc(100% / 9);
+  font-size: 130%;
+  width: calc(100% / 9);
+  height: calc(100% / 9);
 }
 
 input {
@@ -17,6 +20,8 @@ input {
   text-shadow: 1px 1px 1px #000000;
   border-style: none;
   outline: 0 none;
+  width: 100%;
+  height: 100%;
 }
 
 .tl {
@@ -56,20 +61,16 @@ input {
 }
 
 table {
-  top: 50%;
-  left: 50%;
-  margin: 0px auto;
-}
-
-td {
-  width: 70px;
-  height: 70px;
+  width: min(80vw, 60vh);
+  height: min(80vw, 60vh);
+  margin: 0 auto;
 }
 
 h1 {
-  margin: 100px 0 175px 0;
+  height: min(10vw, 10vh);
+  line-height: min(10vw, 10vh);
   text-align: center;
-  font-size: 50px;
+  font-size: min(5vw, 5vh);
   font-family: irohamaru-mikami-Regular;
 }
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
 <html>
+  <meta charset="utf-8" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1, shrink-to-fit=no"
+  />
   <script
     src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.0/jquery.min.js"
     type="text/javascript"

--- a/js/sudoku.js
+++ b/js/sudoku.js
@@ -31,7 +31,7 @@ function displayGrid(arrayToDisplay) {
       table +=
         "<td style='visibility:hidden' class = '" +
         ident +
-        "'><input autocomplete='new-password', tabindex ='1', maxlength = 1, size='1', id = 't" +
+        "'><input autocomplete='new-password', tabindex ='1', maxlength = 1, id = 't" +
         i +
         j +
         "', onkeypress='document.getElementById(\"t" +


### PR DESCRIPTION
I've used some relative CSS units like `vh` and `vw` and the `min` and `calc` CSS functions to attempt to better fit the sudoku grid to any screen shape. Here's my laptop screen for example:
Before:
<img width="500" alt="before" src="https://user-images.githubusercontent.com/8444595/88876149-49dc1780-d1e8-11ea-83ef-a4e7b36d4992.png">
After:
<img width="500" alt="after" src="https://user-images.githubusercontent.com/8444595/88876152-4b0d4480-d1e8-11ea-8331-3a0007b6a37b.png">

Try the chrome dev tools device simulator to see that it also looks much better on phones too! The numbers probably still need more tweaking to get it exactly the way you want it, but hopefully this will help you get started. 🎉  
